### PR TITLE
add new event for Research Data Roundtable

### DIFF
--- a/Australian Digital Observatory/content/events/research-data-roundtable/contents.lr
+++ b/Australian Digital Observatory/content/events/research-data-roundtable/contents.lr
@@ -1,0 +1,24 @@
+title: Research Data Roundtable
+---
+description:
+
+_What are your research data challenges? Tell us at Research Data Roundtable._
+
+Web and social media data are becoming increasingly inaccessible. Platforms such as Twitter and Reddit are making it harder to access research data by closing their APIs or charging for them. These are the new challenges that researchers now have to navigate.
+
+As a research infrastructure facility set out to support HASS and GLAM researchers with their data problems, we at the Australian Digital Observatory would like to understand better the data challenges you are going through. We would like to invite interested researchers to an in-person Research Data Roundtable. Your feedback and input will help us gain insights into researchers' challenges and pain points, and how we can help.
+
+**When**: September 2023 (tentative)
+
+Express your interest via [bit.ly/research-data-roundtable](https://bit.ly/research-data-roundtable).
+
+---
+organiser: QUT Digital Observatory
+---
+type: workshop
+---
+url: https://bit.ly/research-data-roundtable
+---
+where: P Block, GP-638, Gardent Point campus, Queensland University of Technology
+---
+event_date: 


### PR DESCRIPTION
This is the landing page for our Research Data Roundtable. I'll write an update email on this to the team later.

It is a focus group session where we invite researchers to talk about their research data challenges post Twitter API. We'll also leverage this interaction to validate-test our new capabilities, including those that Mat and Rob are working on. 

Event document: https://docs.google.com/document/d/1mFOe93iPioQMi4USM0MtIOEY13dxhHCHuJ54Bn77CUw/edit?usp=sharing 