### PR TITLE
Fix typo in Twitter factsheet

### DIFF
--- a/Australian Digital Observatory/content/factsheets/platform-factsheet-twitter/contents.lr
+++ b/Australian Digital Observatory/content/factsheets/platform-factsheet-twitter/contents.lr
@@ -34,7 +34,7 @@ Rate limits:
 - Free access does not allow tweet retrieval, only tweet creation.
 - Basic access allows you to retrieve 10,000 tweets per month at a cost of US$100 per month.
 - Pro access allows you to retrieve 1,000,000 tweets per month at a cost of US$5,000 per month.
-- Essential access is provided on a case-by-case basis.
+- Enterprise access is provided on a case-by-case basis.
 
 See the following link for more information about [X/Twitter API access levels and versions](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api#v2-access-level).
 


### PR DESCRIPTION
Was meant to say 'Enterprise' not 'Essential'. All fixed now.