### PR TITLE
Fix tag on tidy_tweet

### DIFF
--- a/Australian Digital Observatory/content/resources/tidy-tweet/contents.lr
+++ b/Australian Digital Observatory/content/resources/tidy-tweet/contents.lr
@@ -16,7 +16,7 @@ owner: QUT Digital Observatory
 ---
 poc: digitalobservatory@qut.edu.au
 ---
-tags: tidy
+tags: tidy and model
 ---
 howToUse: tidy_tweet is a fully open-sourced Python package and can be installed with pip (see [tidy_tweet on PyPI](https://pypi.org/project/tidy-tweet/) for more information).
 ---


### PR DESCRIPTION
This is a minor fix to the tidy_tweet resource. The tag should have been 'tidy and model' not 'tidy', my bad. All fixed now.