### PR TITLE
Make cards clickable on the QUT DO landing page

### DIFF
--- a/Australian Digital Observatory/templates/landing-page.html
+++ b/Australian Digital Observatory/templates/landing-page.html
@@ -12,41 +12,47 @@
   <div class="row" id="landing-cards">
     <div class="col d-flex align-items-stretch">
       <div class="card">
-        <div class="card-body">
-          <img src="{{ '/static/images/database-icon.svg'|asseturl }}">
-          <h5 class="card-title">Data infrastructure and development</h5>
-          <p class="card-text">
-          <p>Design and implement project-specific research data workflows</p>
-          <p>Assist with collecting, storing, and tidying data from the web</p>
-          <p>Build and maintain open-source and bespoke software to aid with data collection</p>
-          </p>
-        </div>
+        <a href="https://www.digitalobservatory.net.au/services/data-infrastructure-and-development/" style="text-decoration: none; color: inherit;">
+          <div class="card-body">
+            <img src="{{ '/static/images/database-icon.svg'|asseturl }}">
+            <h5 class="card-title">Data infrastructure and development</h5>
+            <p class="card-text">
+            <p>Design and implement project-specific research data workflows</p>
+            <p>Assist with collecting, storing, and tidying data from the web</p>
+            <p>Build and maintain open-source and bespoke software to aid with data collection</p>
+            </p>
+          </div>
+        </a>
       </div>
     </div>
     <div class="col d-flex align-items-stretch">
       <div class="card">
-        <div class="card-body">
-          <img src="{{ '/static/images/data-science-icon.svg'|asseturl }}">
-          <h5 class="card-title">Data science</h5>
-          <p class="card-text">
-          <p>Assist with data tidying, pre-processing, analysis, and visualisation</p>
-          <p>Assist with text analysis methods including topic modelling, sentiment analysis, and network analysis</p>
-          <p>Build and maintain open-source and bespoke software to aid with data processing and analysis</p>
-          </p>
-        </div>
+        <a href="https://www.digitalobservatory.net.au/services/data-science/" style="text-decoration: none; color: inherit;">
+          <div class="card-body">
+            <img src="{{ '/static/images/data-science-icon.svg'|asseturl }}">
+            <h5 class="card-title">Data science</h5>
+            <p class="card-text">
+            <p>Assist with data tidying, pre-processing, analysis, and visualisation</p>
+            <p>Assist with text analysis methods including topic modelling, sentiment analysis, and network analysis</p>
+            <p>Build and maintain open-source and bespoke software to aid with data processing and analysis</p>
+            </p>
+          </div>
+        </a>
       </div>
     </div>
     <div class="col d-flex align-items-stretch">
       <div class="card">
-        <div class="card-body">
-          <img src="{{ '/static/images/spreadsheet-icon.svg'|asseturl }}">
-          <h5 class="card-title">Databanks and Data governance</h5>
-          <p class="card-text">
-          <p>Provide curated data from existing databanks such as the Australian Twittersphere and Newstalk</p>
-          <p>Provide guidance and advice on data governance associated with human-related data from the web (e.g.
-            reviews, comments, forums, social media data)</p>
-          </p>
-        </div>
+        <a href="https://www.digitalobservatory.net.au/services/databanks-and-data-governance/" style="text-decoration: none; color: inherit;">
+          <div class="card-body">
+            <img src="{{ '/static/images/spreadsheet-icon.svg'|asseturl }}">
+            <h5 class="card-title">Databanks and Data governance</h5>
+            <p class="card-text">
+            <p>Provide curated data from existing databanks such as the Australian Twittersphere and Newstalk</p>
+            <p>Provide guidance and advice on data governance associated with human-related data from the web (e.g.
+              reviews, comments, forums, social media data)</p>
+            </p>
+          </div>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This change makes the three cards on the QUT DO landing page clickable. Each one now links to the three separate service pages.