### PR TITLE
Link to COVID case study from 'data science' service

### DIFF
--- a/Australian Digital Observatory/content/services/data-science/contents.lr
+++ b/Australian Digital Observatory/content/services/data-science/contents.lr
@@ -8,3 +8,10 @@ The Digital Observatory can provide data science support for research projects. 
 - Building and maintaining open-source and bespoke software to aid with data processing and analysis
 
 [Get in touch](/contact-us) with the Digital Observatory team to discuss your project and how we can help.
+---
+extras:
+
+#### caseStudy ####
+title: 100 days of COVID-19 in the Australian Twittersphere
+----
+link: /case-studies/100-days-of-covid-19-in-the-australian-twittersphere/


### PR DESCRIPTION
@boyd-nguyen I referred back to our notes in the issue https://github.com/QUT-Digital-Observatory/australian_digital_observatory_site/issues/78 and realised that we intended to associate the COVID-19 case study with the 'data science' service rather than the 'databanks and data governance' service.

I've added the link to the 'data science' service and left it also associated with the 'databanks and data governance' service since it's probably both. Let me know if you have thoughts on it - I'm also happy to keep each case study strictly to one service as well.