### PR TITLE
Remove reference to roundtable and substitute with researchers' guide

### DIFF
--- a/Australian Digital Observatory/content/blog/rip-australian-twittersphere/contents.lr
+++ b/Australian Digital Observatory/content/blog/rip-australian-twittersphere/contents.lr
@@ -57,9 +57,9 @@ The Digital Observatory is working on resources for web archiving, so watch this
 
 The transition away from Twitter will be uncomfortable for some, but it is important to remember that other sources of data still exist on the Web.
 
-##### Tell us your challenges at our Research Data Roundtable
+Researchers can refer to our [guide to the Australian Twittersphere](/australian-twittersphere) for more information on the Australian Twittersphere and how to access it.
+For a more in-depth technical overview, please read the [Australian Twittersphere technical fact sheet](https://qut-digital-observatory.github.io/australian_twittersphere_fact_sheet/).
 
-For us to navigate the path forward and work out how best to support researchers in this "post-API" world, we would appreciate your feedback and input. Join us at our [Research Data Roundtable](https://bit.ly/research-data-roundtable) and share your research problems, the data you need for your research, and what data-related challenges you are encountering. Express your interest here via this form: https://bit.ly/research-data-roundtable.
 
 ### Publications using the Australian Twittersphere
 


### PR DESCRIPTION
I noticed that the roundtable was mentioned in the blog post about the Australian Twittersphere. I thought it would be best to remove it to avoid any confusion 😺 