### PR TITLE
110 about page

### DIFF
--- a/Australian Digital Observatory/content/about/contents.lr
+++ b/Australian Digital Observatory/content/about/contents.lr
@@ -37,9 +37,6 @@ The Australian Digital Observatory (ADO) will develop and support an ecosystem o
 
 ### Stay in touch
 
-We host a joint [fortnightly office hours](/office-hours) with the [Australian Text Analytics Platform](https://www.atap.edu.au/) and the [Time Layered Cultural Map](https://tlcmap.org/) every second Tuesday afternoon. Drop in to our office hours 
-to chat with us, ask questions, or get support with any of our resources and offerings.
-
-The [QUT Digital Observatory](https://www.qut.edu.au/digital-observatory) runs a regular newsletter which also shares Australian Digital Observatory news - [subscribe](https://research.qut.edu.au/digitalobservatory/newsletter/) to get an update to your inbox every 2-3 months!
+The [QUT Digital Observatory](https://www.qut.edu.au/digital-observatory) runs a regular newsletter which also shares Australian Digital Observatory news - [subscribe](https://qut.us14.list-manage.com/subscribe?u=af4511b1f437a65735ec33554&id=1484bd46e2) to get an update to your inbox every 2-3 months!
 
 

--- a/Australian Digital Observatory/content/office-hours/contents.lr
+++ b/Australian Digital Observatory/content/office-hours/contents.lr
@@ -4,18 +4,18 @@ show_toc:
 ---
 body:
 
-**Office Hours is changing**
+<div class="alert alert-primary" role="alert">
+<h4 class="alert-heading" style="margin-top:auto">Office Hours is changing!</h4>
+ <div>The Digital Observatory and the Language Data Commons of Australia teams are redesigning how office hours will proceed from the start of 2024. Check back at the end of January for updates!</div>
+</div>
 
-The Digital Observatory and the Language Data Commons of Australia teams are redesigning how office hours will proceed from the start of 2024. Check back at the end of January for updates!
+
 
 ### Pre-2024 Office Hours
 
 We invite Australian researchers working with linguistics, text analytics, digital and computational methods, social media and web archives, and much more to attend our regular online office hours. Bring your technical questions, research problems and rough ideas and get advice and feedback from the combined expertise of four ARDC research infrastructure projects.
 
 These sessions run over Zoom from 2-3pm (Australia/Sydney time) every second Tuesday – drop in and bring your research questions relating to all of the topics below (and more!) and ask our experts directly. No question is too small, and even if we don’t know the answer we are likely to be able to point you to who can.
-
-Office Hours will resume for 2023 on 17 January. Click on the register link below for the list of Office Hours sessions this year.
-
 
 ### About the partners
 

--- a/Australian Digital Observatory/content/office-hours/contents.lr
+++ b/Australian Digital Observatory/content/office-hours/contents.lr
@@ -4,165 +4,20 @@ show_toc:
 ---
 body:
 
+**Office Hours is changing**
+
+The Digital Observatory and the Language Data Commons of Australia teams are redesigning how office hours will proceed from the start of 2024. Check back at the end of January for updates!
+
+### Pre-2024 Office Hours
+
 We invite Australian researchers working with linguistics, text analytics, digital and computational methods, social media and web archives, and much more to attend our regular online office hours. Bring your technical questions, research problems and rough ideas and get advice and feedback from the combined expertise of four ARDC research infrastructure projects.
 
 These sessions run over Zoom from 2-3pm (Australia/Sydney time) every second Tuesday – drop in and bring your research questions relating to all of the topics below (and more!) and ask our experts directly. No question is too small, and even if we don’t know the answer we are likely to be able to point you to who can.
 
 Office Hours will resume for 2023 on 17 January. Click on the register link below for the list of Office Hours sessions this year.
 
-### Register to Attend
-
-You can register to attend here: [https://qut.zoom.us/meeting/register/tZIsdOitrj0oEt2j0_PWJRr1wq3KZRDlIeBl](https://qut.zoom.us/meeting/register/tZIsdOitrj0oEt2j0_PWJRr1wq3KZRDlIeBl).
-
-Note that the Zoom link for 2023 is different from the 2022 Zoom link – returning participants will need to re-register for their first attendance in 2023, and then you can continue to use that link for other sessions in 2023.
-
-### What We Can Help With
-
-The following is an incomplete list of the kinds of things we can help with. You can see some more specific details of the partner projects below.
-
-- How can I make interactive web maps for humanities research?
-- How can I find place names in Australia?
-- How can I see change over time on a map?
-- How can I collect data from the web or social media platforms?
-- How can I access and use existing collections of social media data?
-- What kind of analysis can I do with the social media data I have?
-- What are useful tools which I can use in working with text?
-- What sort of analyses are possible with the data which I have?
-- What format should my data be in if I want to carry out a certain analysis?
-- What language data relevant to my problem already exists in Australia?
-- How can I gain access to language data held in different places and collections?
-- I’m trying to use this software for my research, where do I start?
-
-### FAQs
-
-Below are some answers to questions we’d like to be asked. If you have any other questions about Office Hours and whether it’s the right place for you, please reach out to our team via digitalobservatory@qut.edu.au.
-
-<div class="accordion" id="faq-office-hours">
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="headingOne">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-            Why did you start Office Hours?
-            </button>
-        </h4>
-        <div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                We think there’s a need for a community space enabling interdisciplinary discussion of computational and digital approaches to research. As a group of Australian research infrastructure projects we think we’re the right group to get something like this started, and we thought it better to combine our efforts rather than further fragmenting the options.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="headingTwo">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-            Why are these sessions run via Zoom?
-            </button>
-        </h4>
-        <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                These sessions are online first to be accessible to all Australian researchers, we’re not just on Zoom because of the pandemic. The time was chosen to be accessible during business hours from New Zealand to Western Australia.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="headingThree">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
-            Why are these sessions run via Zoom?
-            </button>
-        </h4>
-        <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                These sessions are online first to be accessible to all Australian researchers, we’re not just on Zoom because of the pandemic. The time was chosen to be accessible during business hours from New Zealand to Western Australia.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading4">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse4" aria-expanded="false" aria-controls="collapse4">
-            How do you run sessions?
-            </button>
-        </h4>
-        <div id="collapse4" class="accordion-collapse collapse" aria-labelledby="heading4" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                Our office hours are informal – people are welcome to just drop in. A typical session looks like:
-                <ol>
-                    <li>Introductions around the call for people who are new.</li>
-                    <li>A quick poll of why people are there today: do they have specific questions, or are they here to have a more general discussion? Does someone want to show us something they’ve been working on?</li>
-                    <li>For specific questions we usually allocate a breakout room for the researcher who has brought the question, and assign one of our experts to help them 1:1.</li>
-                    <li>General discussions continue in the main room.</li>
-                </ol>
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading5">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse5" aria-expanded="false" aria-controls="collapse5">
-            I don’t really have a question, can I still drop in?
-            </button>
-        </h4>
-        <div id="collapse5" class="accordion-collapse collapse" aria-labelledby="heading4" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                Of course! We love to meet new people and hear more about what’s happening in people’s research.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading6">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse6" aria-expanded="false" aria-controls="collapse6">
-            Can you help me with X?
-            </button>
-        </h4>
-        <div id="collapse6" class="accordion-collapse collapse" aria-labelledby="heading6" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                If it’s in the list above, we can definitely help. If it’s not in the list above, we might be able to help anyway! Even if we can’t help directly we may be able to point you in the right direction. If you’re at all concerned about whether your question is something we can help with reach out beforehand via email.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading7">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse7" aria-expanded="false" aria-controls="collapse7">
-            I’m just starting with Y, can I ask your advice on where to get started?
-            </button>
-        </h4>
-        <div id="collapse7" class="accordion-collapse collapse" aria-labelledby="heading7" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                Absolutely! We love to talk to people at very early stages – bring along your initial ideas and draw on our collective expertise. We specifically want to help people build on existing resources and materials as well as avoid dead ends.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading8">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse8" aria-expanded="false" aria-controls="collapse8">
-            This is great – how can we help out?
-            </button>
-        </h4>
-        <div id="collapse8" class="accordion-collapse collapse" aria-labelledby="heading8" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                We’d love it if you could help us spread the word. A short blurb in a newsletter or mentioning us to a colleague is much appreciated. If you need more marketing collateral please <a href="mailto:digitalobservatory@qut.edu.au">reach out</a>.
-            </div>
-        </div>
-    </div>
-    <div class="accordion-item">
-        <h4 class="accordion-header" id="heading9">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse9" aria-expanded="false" aria-controls="collapse9">
-            How long are you planning to run these sessions?
-            </button>
-        </h4>
-        <div id="collapse9" class="accordion-collapse collapse" aria-labelledby="heading8" data-bs-parent="#faq-office-hours">
-            <div class="accordion-body">
-                We're planning to continue Office Hours throughout 2023. We will be making adjustments as necessary to the format based on researcher demand and feedback.
-            </div>
-        </div>
-    </div>
-</div>
 
 ### About the partners
-
-#### [Time Layered Cultural Map](https://tlcmap.org/)
-
-TLCMap is a set of tools that work together for mapping Australian history and culture. Some questions we can answer:
-
-- How can I make interactive web maps for humanities research?
-- How can I find place names in Australia?
-- How can I see change over time on a map?
 
 #### Australian Digital Observatory
 


### PR DESCRIPTION
- Change link on About page for newsletter subscription from old research web blog to mailchimp subscription form. Closes #110 
- Remove zoom link from Office Hours page and put a note saying that office hours is changing.