### PR TITLE
Add Atom feed for blog

### DIFF
--- a/Australian Digital Observatory/Australian Digital Observatory.lektorproject
+++ b/Australian Digital Observatory/Australian Digital Observatory.lektorproject
@@ -1,6 +1,7 @@
 [project]
 name = Australian Digital Observatory
 locale = en_AU
+url = https://www.digitalobservatory.net.au
 
 [servers.ghpages]
 default = yes
@@ -9,3 +10,4 @@ target = ghpages://QUT-Digital-Observatory/australian_digital_observatory_site
 [packages]
 lektor-markdown-header-anchors = 0.3.1
 lektor-tags = 0.5.1
+lektor-atom = 0.4.0

--- a/Australian Digital Observatory/configs/atom.ini
+++ b/Australian Digital Observatory/configs/atom.ini
@@ -1,0 +1,6 @@
+[blog]
+name = Australian Digital Observatory blog
+source_path = /blog
+url_path = /blog/feed.xml
+item_model = blog-post
+

--- a/Australian Digital Observatory/templates/blog.html
+++ b/Australian Digital Observatory/templates/blog.html
@@ -1,6 +1,9 @@
 {% extends "layout.html" %}
 {% from "macros/pagination.html" import render_pagination %}
 {% block title %}Australian Digital Observatory's Blog{% endblock %}
+{% block extra_metadata %}
+<link rel="alternate" type="application/atom+xml" title="Digital Observatory blog feed" href="{{ '@atom/blog'|url }}" />
+{% endblock %}
 {% block body %}
 <h1>Blog</h1>
 
@@ -16,4 +19,7 @@
 {% if this.pagination.pages > 1 %}
 {{ render_pagination(this.pagination) }}
 {% endif %}
+
+<p>Subscribe to our blog with: <a href="{{ '@atom/blog'|url }}">RSS/Atom feed</a></p>
+
 {% endblock %}

--- a/Australian Digital Observatory/templates/layout.html
+++ b/Australian Digital Observatory/templates/layout.html
@@ -21,6 +21,7 @@
   <link rel="stylesheet" href="{{ '/static/custom.css'|url }}">
   <link rel="shortcut icon" href="{{ '/static/images/favicon.ico' | asseturl }}"">
   <title>{% block title %}Welcome{% endblock %} — Australian Digital Observatory</title>
+  {% block extra_metadata %}{% endblock %}
 </head>
 <!-- Google tag (gtag.js) -->
 <script async src=" https://www.googletagmanager.com/gtag/js?id=G-96RSB604XP">


### PR DESCRIPTION
- Adds the official lektor atom plugin
- Configures an atom feed for all blog posts
- Adds links (in head and in body) to atom feed on blog main page
- Adds extra metadata block in main layout template to allow adding the extra link tag on the blog main page